### PR TITLE
feat: Implement visual enhancements and dark mode

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -20,6 +20,7 @@
           </li>
         </ul>
         <ul class="hidden-links hidden"></ul>
+        <button id="theme-toggle-button" class="btn btn--small">Dark Mode</button>
       </nav>
     </div>
   </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,4 @@
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
+<script src="{{ base_path }}/assets/js/theme-toggle.js"></script>
 
 {% include analytics.html %}

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -40,7 +40,7 @@ $type-size-7                : 0.6875em; // ~11px
 $type-size-8                : 0.625em;  // ~10px
 
 $global-font-family         : $sans-serif;
-$header-font-family         : $sans-serif;
+$header-font-family         : "Nunito Sans", $sans-serif;
 $caption-font-family        : $serif;
 
 /* ==========================================================================

--- a/_sass/layout/_base.scss
+++ b/_sass/layout/_base.scss
@@ -97,10 +97,11 @@ abbr[data-original-title] {
 
 blockquote {
   margin: 2em 1em 2em 0;
-  padding-left: 1em;
+  padding-left: 1.25em;
   padding-right: 1em;
   font-style: italic;
-  border-left: 0.25em solid var(--global-border-color);
+  border-left: 0.25em solid var(--global-accent-color);
+  background-color: darken(var(--global-bg-color), 3%);
 
   cite {
     font-style: italic;

--- a/_sass/layout/_buttons.scss
+++ b/_sass/layout/_buttons.scss
@@ -17,13 +17,15 @@
   font-weight: bold;
   text-align: center;
   text-decoration: none;
-  background-color: var(--global-base-color);
+  background-color: var(--global-accent-color);
   border: 0 !important;
   border-radius: $border-radius;
   cursor: pointer;
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
   &:hover {
-    background-color: mix(white, #000, 20%);
+    background-color: mix(#000, var(--global-accent-color), 15%);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   .icon {
@@ -48,13 +50,13 @@
   /* for dark backgrounds */
 
   &--inverse {
-    color: var(--global-text-color-light) !important;
-    border: 1px solid var(--global-border-color) !important; /* override*/
+    color: var(--global-accent-color) !important;
+    border: 1px solid var(--global-accent-color) !important; /* override*/
     background-color: var(--global-bg-color);
 
     &:hover {
+      background-color: var(--global-accent-color);
       color: #fff !important;
-      border-color: var(--global-text-color-light);
     }
   }
 

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -96,10 +96,16 @@
   img {
     max-width: 175px;
     border-radius: 50%;
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
     @include breakpoint($large) {
       padding: 5px;
       border: 1px solid var(--global-border-color);
+    }
+
+    &:hover {
+      transform: scale(1.05);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }
   }
 }
@@ -256,9 +262,15 @@
     color: inherit;
     font-size: $type-size-5;
     text-decoration: none;
+    transition: color 0.2s ease-in-out;
 
     &:hover {
-      text-decoration: underline;
+      color: var(--global-accent-color);
+      text-decoration: underline; // Keep underline
+
+      i { // Assuming icons are <i> tags
+        color: var(--global-accent-color);
+      }
     }
   }
 }

--- a/_sass/theme/_dark.scss
+++ b/_sass/theme/_dark.scss
@@ -37,18 +37,24 @@ $sidebar-screen-min-width   : 1024px;
 html[data-theme="dark"] {
     --global-base-color                 : #{$background};
     --global-bg-color                   : #{$background};
-    --global-footer-bg-color            : #{$background};
+    --global-footer-bg-color            : #{lighten($background, 5%)};
     --global-border-color               : #{$light-gray};
     --global-dark-border-color          : #{$background-light};
-    --global-code-background-color      : #fafafa;
-    --global-code-text-color            : #{$darker-gray};
+    --global-code-background-color      : #282c34;
+    --global-code-text-color            : #abb2bf;
     --global-fig-caption-color          : #{$dark-gray};
-    --global-link-color                 : #{$link};
-    --global-link-color-hover           : #{$link-dark};
-    --global-link-color-visited         : #{$link-light};
+    --global-accent-color               : #58a6ff;
+    --global-link-color                 : #{$link}; // #0ea1c5
+    --global-link-color-hover           : #{$link-light}; // #53cbf1
+    --global-link-color-visited         : #{$link-dark}; // #0a7189
     --global-masthead-link-color        : #{$text};
     --global-masthead-link-color-hover  : #{$background-light};
     --global-text-color                 : #{$text};
     --global-text-color-light           : #{$light-gray};
-    --global-thead-color                : #{$background-lighter};
+    --global-thead-color                : #{lighten($background, 10%)};
+
+    blockquote {
+      background-color: #{lighten($background, 5%)};
+      border-left-color: var(--global-accent-color);
+    }
 }

--- a/_sass/theme/_default.scss
+++ b/_sass/theme/_default.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&display=swap');
+
 /* ==========================================================================
    DEFAULT THEME
    ========================================================================== */
@@ -29,16 +31,17 @@ $sidebar-screen-min-width   : 1024px;
 /* Default light theme for the site */
 :root {
     --global-base-color                 : #{$gray};
-    --global-bg-color                   : #fff;
-    --global-footer-bg-color            : #f2f3f3;
+    --global-bg-color                   : #f8f9fa;
+    --global-accent-color               : #4A90E2;
+    --global-footer-bg-color            : #e9ecef;
     --global-border-color               : #{$lighter-gray};
     --global-dark-border-color          : #bdc1c4;
-    --global-code-background-color      : #fafafa;
+    --global-code-background-color      : #e9ecef;
     --global-code-text-color            : #{$darker-gray};
     --global-fig-caption-color          : mix(#fff,  #{$dark-gray}, 25%);
-    --global-link-color                 : #52adc8;
-    --global-link-color-hover           : mix(#000, #2f7f93, 25%);
-    --global-link-color-visited         : mix(#fff, #2f7f93, 25%);  
+    --global-link-color                 : #007bff;
+    --global-link-color-hover           : #0056b3;
+    --global-link-color-visited         : #0056b3;
     --global-masthead-link-color        : #{$dark-gray};
     --global-masthead-link-color-hover  : mix(#000, #{$gray}, 25%);    
     --global-text-color                 : #{$dark-gray};

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const themeToggleButton = document.getElementById('theme-toggle-button');
+    const currentTheme = localStorage.getItem('theme') || 'light'; // Default to light
+
+    function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (themeToggleButton) {
+            themeToggleButton.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+        }
+    }
+
+    applyTheme(currentTheme); // Apply saved theme on load
+
+    if (themeToggleButton) {
+        themeToggleButton.addEventListener('click', function () {
+            let newTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+        });
+    }
+});


### PR DESCRIPTION
This commit introduces a range of visual improvements to the site and adds a user-toggleable dark mode feature.

Key changes include:

1.  **Color Scheme:**
    *   Global background changed to a softer off-white (#f8f9fa).
    *   New primary accent color (#4A90E2) introduced.
    *   Link colors updated to a modern blue (#007bff) with revised
        hover/visited states.
    *   Adjusted code block and footer backgrounds for better harmony.

2.  **Typography:**
    *   'Nunito Sans' web font implemented for headers for a more
        modern look. Body text continues to use system UI fonts.

3.  **Sidebar:**
    *   Author avatar now has scale and shadow hover effects.
    *   Sidebar links (social/academic) use the accent color on hover.

4.  **UI Elements:**
    *   Default and inverse buttons restyled to use the accent color,
        with improved hover effects and subtle shadows.
    *   Blockquotes now feature the accent color for their left border
        and a slightly differentiated background.

5.  **Dark Mode:**
    *   Comprehensive dark theme variables defined in `_sass/theme/_dark.scss`,
        harmonizing with the new accent and link colors.
    *   A JavaScript theme toggle button added to the masthead.
    *   Your theme preference is saved in localStorage.

These changes aim to provide a cleaner, more modern, accessible, and visually engaging user experience.