### PR TITLE
I've resolved a Sass build error and applied theme-compatible enhance…

### DIFF
--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -40,7 +40,7 @@ $type-size-7                : 0.6875em; // ~11px
 $type-size-8                : 0.625em;  // ~10px
 
 $global-font-family         : $sans-serif;
-$header-font-family         : "Nunito Sans", $sans-serif;
+$header-font-family         : $sans-serif;
 $caption-font-family        : $serif;
 
 /* ==========================================================================

--- a/_sass/layout/_base.scss
+++ b/_sass/layout/_base.scss
@@ -101,7 +101,7 @@ blockquote {
   padding-right: 1em;
   font-style: italic;
   border-left: 0.25em solid var(--global-accent-color);
-  background-color: darken(var(--global-bg-color), 3%);
+  background-color: rgba(0, 0, 0, 0.03);
 
   cite {
     font-style: italic;

--- a/_sass/layout/_buttons.scss
+++ b/_sass/layout/_buttons.scss
@@ -17,15 +17,13 @@
   font-weight: bold;
   text-align: center;
   text-decoration: none;
-  background-color: var(--global-accent-color);
+  background-color: var(--global-base-color);
   border: 0 !important;
   border-radius: $border-radius;
   cursor: pointer;
-  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
   &:hover {
-    background-color: mix(#000, var(--global-accent-color), 15%);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: mix(white, #000, 20%);
   }
 
   .icon {
@@ -50,13 +48,13 @@
   /* for dark backgrounds */
 
   &--inverse {
-    color: var(--global-accent-color) !important;
-    border: 1px solid var(--global-accent-color) !important; /* override*/
+    color: var(--global-text-color-light) !important;
+    border: 1px solid var(--global-border-color) !important; /* override*/
     background-color: var(--global-bg-color);
 
     &:hover {
-      background-color: var(--global-accent-color);
       color: #fff !important;
+      border-color: var(--global-text-color-light);
     }
   }
 

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -96,16 +96,10 @@
   img {
     max-width: 175px;
     border-radius: 50%;
-    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 
     @include breakpoint($large) {
       padding: 5px;
       border: 1px solid var(--global-border-color);
-    }
-
-    &:hover {
-      transform: scale(1.05);
-      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }
   }
 }
@@ -262,15 +256,9 @@
     color: inherit;
     font-size: $type-size-5;
     text-decoration: none;
-    transition: color 0.2s ease-in-out;
 
     &:hover {
-      color: var(--global-accent-color);
-      text-decoration: underline; // Keep underline
-
-      i { // Assuming icons are <i> tags
-        color: var(--global-accent-color);
-      }
+      text-decoration: underline;
     }
   }
 }

--- a/_sass/theme/_dark.scss
+++ b/_sass/theme/_dark.scss
@@ -35,26 +35,57 @@ $sidebar-screen-min-width   : 1024px;
 
 /* Dark theme for the site */
 html[data-theme="dark"] {
-    --global-base-color                 : #{$background};
-    --global-bg-color                   : #{$background};
-    --global-footer-bg-color            : #{lighten($background, 5%)};
-    --global-border-color               : #{$light-gray};
-    --global-dark-border-color          : #{$background-light};
-    --global-code-background-color      : #282c34;
-    --global-code-text-color            : #abb2bf;
-    --global-fig-caption-color          : #{$dark-gray};
-    --global-accent-color               : #58a6ff;
-    --global-link-color                 : #{$link}; // #0ea1c5
-    --global-link-color-hover           : #{$link-light}; // #53cbf1
-    --global-link-color-visited         : #{$link-dark}; // #0a7189
-    --global-masthead-link-color        : #{$text};
-    --global-masthead-link-color-hover  : #{$background-light};
-    --global-text-color                 : #{$text};
-    --global-text-color-light           : #{$light-gray};
-    --global-thead-color                : #{lighten($background, 10%)};
+  --custom-accent-color-dark: #58a6ff;
+  --custom-visited-link-color-dark: #9075d8;
+  --global-accent-color: var(--custom-accent-color-dark); // Define global to be custom for dark
 
-    blockquote {
-      background-color: #{lighten($background, 5%)};
-      border-left-color: var(--global-accent-color);
-    }
+  /* Attempt to override some of the older global variables for dark mode consistency */
+  --global-bg-color                   : #121212; /* Use body background for global */
+  --global-text-color                 : #e0e0e0; /* Use body color for global */
+  --global-link-color                 : var(--custom-accent-color-dark);
+  --global-link-color-hover           : var(--custom-accent-color-dark); /* Consider a slightly lighter version for hover */
+  --global-link-color-visited         : var(--custom-visited-link-color-dark);
+  --global-code-background-color      : #1e1e1e;
+  --global-code-text-color            : #d4d4d4;
+  --global-border-color               : #333; /* General border color for dark theme */
+
+  /* Keep some of the original dark theme variables if they make sense, or override */
+  --global-base-color                 : #{$background}; /* Original dark base */
+  --global-footer-bg-color            : #1c1c1c; /* Slightly different from body */
+  --global-dark-border-color          : #444; /* Darker borders */
+  --global-fig-caption-color          : #{$light-gray}; /* Lighter fig caption */
+  --global-masthead-link-color        : #e0e0e0;
+  --global-masthead-link-color-hover  : #fff;
+  --global-text-color-light           : #{$light-gray};
+  --global-thead-color                : #1e1e1e; /* Match code blocks */
+
+  body {
+    background-color: #121212;
+    color: #e0e0e0;
+  }
+
+  a {
+    color: var(--custom-accent-color-dark); // Use the specific dark variable for links
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  a:visited {
+    color: var(--custom-visited-link-color-dark);
+  }
+
+  pre,
+  code {
+    background-color: #1e1e1e;
+    color: #d4d4d4;
+    border: 1px solid #333;
+  }
+
+  blockquote {
+    background-color: rgba(255, 255, 255, 0.05);
+    /* border-left-color will now correctly use var(--global-accent-color) which is overridden for dark mode */
+  }
 }

--- a/_sass/theme/_default.scss
+++ b/_sass/theme/_default.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&display=swap');
-
 /* ==========================================================================
    DEFAULT THEME
    ========================================================================== */
@@ -31,20 +29,36 @@ $sidebar-screen-min-width   : 1024px;
 /* Default light theme for the site */
 :root {
     --global-base-color                 : #{$gray};
-    --global-bg-color                   : #f8f9fa;
-    --global-accent-color               : #4A90E2;
-    --global-footer-bg-color            : #e9ecef;
+    --global-bg-color                   : #fff;
+    --global-footer-bg-color            : #f2f3f3;
     --global-border-color               : #{$lighter-gray};
     --global-dark-border-color          : #bdc1c4;
-    --global-code-background-color      : #e9ecef;
+    --global-code-background-color      : #fafafa;
     --global-code-text-color            : #{$darker-gray};
     --global-fig-caption-color          : mix(#fff,  #{$dark-gray}, 25%);
-    --global-link-color                 : #007bff;
-    --global-link-color-hover           : #0056b3;
-    --global-link-color-visited         : #0056b3;
+    --global-link-color                 : #52adc8;
+    --global-link-color-hover           : mix(#000, #2f7f93, 25%);
+    --global-link-color-visited         : mix(#fff, #2f7f93, 25%);
     --global-masthead-link-color        : #{$dark-gray};
     --global-masthead-link-color-hover  : mix(#000, #{$gray}, 25%);    
     --global-text-color                 : #{$dark-gray};
     --global-text-color-light           : #{$light-gray};
     --global-thead-color                : #{$lighter-gray};
+
+    --custom-accent-color-light         : #007bff;
+    --custom-visited-link-color-light   : #551a8b; // Traditional purple
+    --global-accent-color               : var(--custom-accent-color-light); // Define global to be custom for light
+}
+
+a {
+  color: var(--custom-accent-color-light);
+  text-decoration: none; /* Common to remove underline by default */
+}
+
+a:hover {
+  text-decoration: underline; /* Underline on hover is a common pattern */
+}
+
+a:visited {
+  color: var(--custom-visited-link-color-light);
 }


### PR DESCRIPTION
…ments to your project.

This update addresses a Jekyll build failure caused by a Sass error and implements visual enhancements in a way that is more compatible with the `jekyll-theme-primer`.

Fixes:
- I corrected a Sass error in `_sass/layout/_base.scss` where `darken(var(--global-bg-color))` was used for the blockquote background. I changed it to `rgba(0, 0, 0, 0.03)` for compatibility.

Reversions:
- I reverted incompatible SASS changes from the previous visual enhancement attempt that were not aligned with `jekyll-theme-primer`. This affected files in `_sass/theme/`, `_sass/layout/`, and `_sass/_themes.scss`.

Enhancements:
- I defined a new CSS custom property `--custom-accent-color-light` (#007bff) and applied it to links in light mode.
- I defined `--custom-accent-color-dark` (#58a6ff) for dark mode links.
- I established `--global-accent-color` to use these custom accent colors in light and dark modes respectively, ensuring elements like blockquote borders use the correct accent.
- I implemented basic dark mode styles in `_sass/theme/_dark.scss` for body background, text color, link colors, code blocks, and blockquote background.
- The existing dark mode toggle button and JavaScript should now function with these theme-compatible styles.